### PR TITLE
Require relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ get "/user_media_feed" do
   client = Instagram.client(:access_token => session[:access_token])
   user = client.user
   html = "<h1>#{user.username}'s media feed</h1>"
-  
+
   page_1 = client.user_media_feed(777)
   page_2_max_id = page_1.pagination.next_max_id
   page_2 = client.user_recent_media(777, :max_id => page_2_max_id ) unless page_2_max_id.nil?
@@ -250,5 +250,5 @@ Complete your CLA here: [https://code.facebook.com/cla](https://code.facebook.co
 Copyright
 ---------
 Copyright (c) 2014, Facebook, Inc. All rights reserved.
-By contributing to Instgram Ruby Gem, you agree that your contributions will be licensed under its BSD license.
+By contributing to Instagram Ruby Gem, you agree that your contributions will be licensed under its BSD license.
 See [LICENSE](https://github.com/Instagram/instagram-ruby-gem/blob/master/LICENSE.md) for details.

--- a/instagram.gemspec
+++ b/instagram.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/instagram/version', __FILE__)
+require_relative '../lib/instagram/version'
 
 Gem::Specification.new do |s|
   s.add_development_dependency('rake', '~> 0.9.2.2')

--- a/lib/instagram.rb
+++ b/lib/instagram.rb
@@ -1,8 +1,8 @@
-require File.expand_path('../instagram/error', __FILE__)
-require File.expand_path('../instagram/configuration', __FILE__)
-require File.expand_path('../instagram/api', __FILE__)
-require File.expand_path('../instagram/client', __FILE__)
-require File.expand_path('../instagram/response', __FILE__)
+require_relative 'instagram/error'
+require_relative 'instagram/configuration'
+require_relative 'instagram/api'
+require_relative 'instagram/client'
+require_relative 'instagram/response'
 
 module Instagram
   extend Configuration

--- a/lib/instagram/api.rb
+++ b/lib/instagram/api.rb
@@ -1,6 +1,6 @@
-require File.expand_path('../connection', __FILE__)
-require File.expand_path('../request', __FILE__)
-require File.expand_path('../oauth', __FILE__)
+require_relative 'connection'
+require_relative 'request'
+require_relative 'oauth'
 
 module Instagram
   # @private

--- a/lib/instagram/configuration.rb
+++ b/lib/instagram/configuration.rb
@@ -1,5 +1,5 @@
 require 'faraday'
-require File.expand_path('../version', __FILE__)
+require_relative 'version'
 
 module Instagram
   # Defines constants and methods related to configuration

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../spec_helper', __FILE__)
+require_relative '../spec_helper'
 
 describe Faraday::Response do
   before do

--- a/spec/instagram/api_spec.rb
+++ b/spec/instagram/api_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../spec_helper', __FILE__)
+require_relative '../spec_helper'
 
 describe Instagram::API do
   before do

--- a/spec/instagram/client/comments_spec.rb
+++ b/spec/instagram/client/comments_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../spec_helper', __FILE__)
+require_relative '../../spec_helper'
 
 describe Instagram::Client do
   Instagram::Configuration::VALID_FORMATS.each do |format|

--- a/spec/instagram/client/embedding_spec.rb
+++ b/spec/instagram/client/embedding_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../spec_helper', __FILE__)
+require_relative '../../spec_helper'
 
 describe Instagram::Client do
   Instagram::Configuration::VALID_FORMATS.each do |format|

--- a/spec/instagram/client/geography_spec.rb
+++ b/spec/instagram/client/geography_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../spec_helper', __FILE__)
+require_relative '../../spec_helper'
 
 describe Instagram::Client do
   Instagram::Configuration::VALID_FORMATS.each do |format|
@@ -7,7 +7,7 @@ describe Instagram::Client do
         @client = Instagram::Client.new(:format => format, :client_id => 'CID', :client_secret => 'CS', :access_token => 'AT')
       end
 
-      
+
       describe ".geography_recent_media" do
 
         context "with geography ID passed" do

--- a/spec/instagram/client/likes_spec.rb
+++ b/spec/instagram/client/likes_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../spec_helper', __FILE__)
+require_relative '../../spec_helper'
 
 describe Instagram::Client do
   Instagram::Configuration::VALID_FORMATS.each do |format|

--- a/spec/instagram/client/locations_spec.rb
+++ b/spec/instagram/client/locations_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../spec_helper', __FILE__)
+require_relative '../../spec_helper'
 
 describe Instagram::Client do
   Instagram::Configuration::VALID_FORMATS.each do |format|

--- a/spec/instagram/client/media_spec.rb
+++ b/spec/instagram/client/media_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../spec_helper', __FILE__)
+require_relative '../../spec_helper'
 
 describe Instagram::Client do
   Instagram::Configuration::VALID_FORMATS.each do |format|

--- a/spec/instagram/client/subscriptions_spec.rb
+++ b/spec/instagram/client/subscriptions_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../spec_helper', __FILE__)
+require_relative '../../spec_helper'
 
 describe Instagram::Client do
   Instagram::Configuration::VALID_FORMATS.each do |format|

--- a/spec/instagram/client/tags_spec.rb
+++ b/spec/instagram/client/tags_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../spec_helper', __FILE__)
+require_relative '../../spec_helper'
 
 describe Instagram::Client do
   Instagram::Configuration::VALID_FORMATS.each do |format|

--- a/spec/instagram/client/users_spec.rb
+++ b/spec/instagram/client/users_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../spec_helper', __FILE__)
+require_relative '../../spec_helper'
 
 describe Instagram::Client do
   Instagram::Configuration::VALID_FORMATS.each do |format|
@@ -195,7 +195,7 @@ describe Instagram::Client do
       end
 
       describe ".user_liked_media" do
-        
+
         before do
           stub_get("users/self/media/liked.#{format}").
             with(:query => {:access_token => @client.access_token}).
@@ -209,7 +209,7 @@ describe Instagram::Client do
             should have_been_made
         end
       end
-      
+
       describe ".user_recent_media" do
 
         context "with user ID passed" do
@@ -272,148 +272,148 @@ describe Instagram::Client do
           users.first.username.should == "shayne"
         end
       end
-      
+
       describe ".user_relationship" do
-        
+
         before do
           stub_get("users/4/relationship.#{format}").
             with(:query => {:access_token => @client.access_token}).
             to_return(:body => fixture("relationship.#{format}"), :headers => {:content_type => "application/#{format}; charset=utf-8"})
         end
-        
+
         it "should get the correct resource" do
           @client.user_relationship(4)
           a_get("users/4/relationship.#{format}").
             with(:query => {:access_token => @client.access_token}).
             should have_been_made
         end
-        
+
         it "should return a relationship status response" do
           status = @client.user_relationship(4)
           status.incoming_status.should == "requested_by"
         end
       end
-      
+
       describe ".follow_user" do
-        
+
         before do
           stub_post("users/4/relationship.#{format}").
             with(:body => {:action => "follow", :access_token => @client.access_token}).
             to_return(:body => fixture("follow_user.#{format}"), :headers => {:content_type => "application/#{format}; charset=utf-8"})
         end
-        
+
         it "should get the correct resource" do
           @client.follow_user(4)
           a_post("users/4/relationship.#{format}").
             with(:body => {:action => "follow", :access_token => @client.access_token}).
             should have_been_made
         end
-        
+
         it "should return a relationship status response" do
           status = @client.follow_user(4)
           status.outgoing_status.should == "requested"
         end
       end
-      
+
       describe ".unfollow_user" do
-        
+
         before do
           stub_post("users/4/relationship.#{format}").
             with(:body => {:action => "unfollow", :access_token => @client.access_token}).
             to_return(:body => fixture("unfollow_user.#{format}"), :headers => {:content_type => "application/#{format}; charset=utf-8"})
         end
-        
+
         it "should get the correct resource" do
           @client.unfollow_user(4)
           a_post("users/4/relationship.#{format}").
             with(:body => {:action => "unfollow", :access_token => @client.access_token}).
             should have_been_made
         end
-        
+
         it "should return a relationship status response" do
           status = @client.unfollow_user(4)
           status.outgoing_status.should == "none"
         end
       end
-      
+
       describe ".block_user" do
-        
+
         before do
           stub_post("users/4/relationship.#{format}").
             with(:body => {:action => "block", :access_token => @client.access_token}).
             to_return(:body => fixture("block_user.#{format}"), :headers => {:content_type => "application/#{format}; charset=utf-8"})
         end
-        
+
         it "should get the correct resource" do
           @client.block_user(4)
           a_post("users/4/relationship.#{format}").
             with(:body => {:action => "block", :access_token => @client.access_token}).
             should have_been_made
         end
-        
+
         it "should return a relationship status response" do
           status = @client.block_user(4)
           status.outgoing_status.should == "none"
         end
       end
-      
+
       describe ".unblock_user" do
-        
+
         before do
           stub_post("users/4/relationship.#{format}").
             with(:body => {:action => "unblock", :access_token => @client.access_token}).
             to_return(:body => fixture("unblock_user.#{format}"), :headers => {:content_type => "application/#{format}; charset=utf-8"})
         end
-        
+
         it "should get the correct resource" do
           @client.unblock_user(4)
           a_post("users/4/relationship.#{format}").
             with(:body => {:action => "unblock", :access_token => @client.access_token}).
             should have_been_made
         end
-        
+
         it "should return a relationship status response" do
           status = @client.unblock_user(4)
           status.outgoing_status.should == "none"
         end
       end
-      
+
       describe ".approve_user" do
-        
+
         before do
           stub_post("users/4/relationship.#{format}").
             with(:body => {:action => "approve", :access_token => @client.access_token}).
             to_return(:body => fixture("approve_user.#{format}"), :headers => {:content_type => "application/#{format}; charset=utf-8"})
         end
-        
+
         it "should get the correct resource" do
           @client.approve_user(4)
           a_post("users/4/relationship.#{format}").
             with(:body => {:action => "approve", :access_token => @client.access_token}).
             should have_been_made
         end
-        
+
         it "should return a relationship status response" do
           status = @client.approve_user(4)
           status.outgoing_status.should == "follows"
         end
       end
-      
+
       describe ".deny_user" do
-        
+
         before do
           stub_post("users/4/relationship.#{format}").
             with(:body => {:action => "deny", :access_token => @client.access_token}).
             to_return(:body => fixture("deny_user.#{format}"), :headers => {:content_type => "application/#{format}; charset=utf-8"})
         end
-        
+
         it "should get the correct resource" do
           @client.deny_user(4)
           a_post("users/4/relationship.#{format}").
             with(:body => {:action => "deny", :access_token => @client.access_token}).
             should have_been_made
         end
-        
+
         it "should return a relationship status response" do
           status = @client.deny_user(4)
           status.outgoing_status.should == "none"

--- a/spec/instagram/client/utils_spec.rb
+++ b/spec/instagram/client/utils_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../spec_helper', __FILE__)
+require_relative '../../spec_helper'
 
 describe Instagram::Client do
   Instagram::Configuration::VALID_FORMATS.each do |format|

--- a/spec/instagram/client_spec.rb
+++ b/spec/instagram/client_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../spec_helper', __FILE__)
+require_relative '../spec_helper'
 
 describe Instagram::Client do
   it "should connect using the endpoint configuration" do

--- a/spec/instagram/request_spec.rb
+++ b/spec/instagram/request_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../spec_helper', __FILE__)
+require_relative '../spec_helper'
 
 describe Instagram::Request do
   describe "#post" do

--- a/spec/instagram_spec.rb
+++ b/spec/instagram_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../spec_helper', __FILE__)
+require_relative 'spec_helper'
 
 describe Instagram do
   after do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ else
   end
 end
 
-require File.expand_path('../../lib/instagram', __FILE__)
+require_relative '../lib/instagram'
 
 require 'rspec'
 require 'webmock/rspec'


### PR DESCRIPTION
- Fix a typo in `README.md` file
- Change `require File.expand_path('../../filename', __FILE__)` to `require_relative '../../filename'`. It's more intuitive and is a bit faster than using require+File.expand_path. 

Reference: https://github.com/rspec/rspec-core/blob/master/benchmarks/require_relative_v_require.rb
