### PR TITLE
Add support for searching locations by a Facebook Places ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ get "/user_media_feed" do
   client = Instagram.client(:access_token => session[:access_token])
   user = client.user
   html = "<h1>#{user.username}'s media feed</h1>"
-  
+
   page_1 = client.user_media_feed(777)
   page_2_max_id = page_1.pagination.next_max_id
   page_2 = client.user_recent_media(777, :max_id => page_2_max_id ) unless page_2_max_id.nil?
@@ -169,6 +169,15 @@ get "/location_search_4square" do
   client = Instagram.client(:access_token => session[:access_token])
   html = "<h1>Search for a location by Fousquare ID (v2)</h1>"
   for location in client.location_search("3fd66200f964a520c5f11ee3")
+    html << "<li> #{location.name} <a href='https://www.google.com/maps/preview/@#{location.latitude},#{location.longitude},19z'>Map</a></li>"
+  end
+  html
+end
+
+get "/location_search_facebook" do
+  client = Instagram.client(:access_token => session[:access_token])
+  html = "<h1>Search for a location by Facebooks Places ID</h1>"
+  for location in client.location_search_facebook_places_id("175495679140580")
     html << "<li> #{location.name} <a href='https://www.google.com/maps/preview/@#{location.latitude},#{location.longitude},19z'>Map</a></li>"
   end
   html

--- a/lib/instagram/client/locations.rb
+++ b/lib/instagram/client/locations.rb
@@ -45,7 +45,7 @@ module Instagram
       #   @param lat [String] A given latitude in decimal format
       #   @param lng [String] A given longitude in decimal format
       #   @option options [Integer] :count The number of media items to retrieve.
-      #   @return [Hashie::Mash] location resultm object, #data is an Array.
+      #   @return [Hashie::Mash] location result object, #data is an Array.
       #   @example 1: Return a location with the Foursquare Venue ID = ()
       #     Instagram.location_search("3fd66200f964a520c5f11ee3") (Schiller's Liquor Bar, 131 Rivington St., NY, NY 10002)
       #   @example 2: Return locations around 37.7808851, -122.3948632 (164 S Park, SF, CA USA)
@@ -67,6 +67,21 @@ module Instagram
           lat, lng, distance = args
           response = get('locations/search', options.merge(:lat => lat, :lng => lng, :distance => distance))
         end
+        response
+      end
+
+      # Returns Instagram locations by Facebook Place ID
+      #
+      # @overload location_search(options={})
+      #   @param facebook_id [String] A valid Facebook Place ID. Must be an integer.
+      #   @return [Hashie::Mash] location result object, #data is an Array.
+      # @see http://instagram.com/developer/endpoints/locations/#get_locations_search
+      # @format :json
+      # @authenticated false
+      # @rate_limited true
+      def location_search_facebook_places_id(facebook_id, *args)
+        options = args.last.is_a?(Hash) ? args.pop : {}
+        response = get('locations/search', options.merge(:facebook_places_id => facebook_id))
         response
       end
     end

--- a/spec/fixtures/location_search_facebook.json
+++ b/spec/fixtures/location_search_facebook.json
@@ -1,0 +1,1 @@
+{"meta":{"code":200},"data":[{"latitude":42.962910034,"id":"2714569","longitude":-85.664197863,"name":"Bartertown Diner"}]}

--- a/spec/instagram/client/locations_spec.rb
+++ b/spec/instagram/client/locations_spec.rb
@@ -122,6 +122,29 @@ describe Instagram::Client do
         end
       end
 
+      describe ".location_search_facebook_places_id" do
+        before do
+          stub_get("locations/search.#{format}").
+            with(:query => {:access_token => @client.access_token}).
+            with(:query => {:facebook_places_id => "175495679140580"}).
+            to_return(:body => fixture("location_search_facebook.#{format}"), :headers => {:content_type => "application/#{format}; charset=utf-8"})
+        end
+
+        it "should get the correct resource by facebook_place_id" do
+          @client.location_search_facebook_places_id("175495679140580")
+          a_get("locations/search.#{format}").
+            with(:query => {:access_token => @client.access_token}).
+            with(:query => {:facebook_places_id => "175495679140580"}).
+            should have_been_made
+        end
+
+        it "should return an array of user search results" do
+          locations = @client.location_search_facebook_places_id("175495679140580")
+          locations.should be_a Array
+          locations.first.name.should == "Bartertown Diner"
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Working on a project and found that searching by Facebook Place IDs would be useful!

I couldn't think of a good, clean way to query by another UUID with the way `#location_search` is currently implemented. I'm definitely open to suggestions.

To not break current usage, I ended up adding another method, naming it following the current pattern in the specs.

I can tweak depending on your suggestions. Thanks!