### PR TITLE
Pass signature option to create_subscription and delete_subscription

### DIFF
--- a/lib/instagram/client/subscriptions.rb
+++ b/lib/instagram/client/subscriptions.rb
@@ -63,7 +63,7 @@ module Instagram
           o[:callback_url] = callback_url unless callback_url.nil?
           o[:aspect] = aspect || o[:aspect] || "media"
         }
-        response = post("subscriptions", options.merge(:client_secret => client_secret))
+        response = post("subscriptions", options.merge(:client_secret => client_secret), signature=true)
         response
       end
 
@@ -92,7 +92,7 @@ module Instagram
         options = args.last.is_a?(Hash) ? args.pop : {}
         subscription_id = args.first
         options.merge!(:id => subscription_id) if subscription_id
-        response = delete("subscriptions", options.merge(:client_secret => client_secret))
+        response = delete("subscriptions", options.merge(:client_secret => client_secret), signature=true)
         response
       end
 


### PR DESCRIPTION
If the _Enforce Signed Header_ option is checked or a client in the Instagram API client options, the ```#create_subscription``` and ```#delete_subscription``` methods will fail, even if Instagram client is configured with the ```client_ips``` option.

```ruby
Instagram.configure do |config|
  config.client_id = CLIENT_ID
  config.client_secret = CLIENT_SECRET
  config.access_token = ACCESS_TOKEN
end

client = Instagram.client(client_ips: 127.0.0.1)
args = {
  object: 'tag',
  object_id: 'blah',
  callback_url: 'example.com/auth',
  aspect: "media",
  verify_token: 'verify',
}
res = client.create_subscription(args)
puts res.inspect

# => <Hashie::Mash code=403 error_message="Invalid header: X-Insta-Forwarded-For is required for this operation" error_type="OAuthForbiddenException">
```

This simple changeset restores functionality. The API documentation at https://instagram.com/developer/restrict-api-requests/# appears to be out of date.

I did not add any new tests because I did not see any other tests specifically testing this behavior, but I can do so if needed.