### PR TITLE
:bug: Convert all params keys to string

### DIFF
--- a/lib/instagram/request.rb
+++ b/lib/instagram/request.rb
@@ -71,6 +71,7 @@ module Instagram
 
     def generate_sig(endpoint, params, secret)
       sig = endpoint
+      params = Hash[params.map{ |k, v| [k.to_s, v] }]
       params.sort.map do |key, val|
         sig += '|%s=%s' % [key, val]
       end


### PR DESCRIPTION
When trying to sort a hash of mixed keys (String and Symbols) an exception occurs, "comparison of Array with Array failed".

This is due to sort using <=> which which doesn't work when comparing string to symbols.