### PR TITLE
adds absolute path to oembed GET as DEFAULT_ENDPOINT is not supported

### DIFF
--- a/lib/instagram/client/embedding.rb
+++ b/lib/instagram/client/embedding.rb
@@ -21,7 +21,7 @@ module Instagram
       def oembed(*args)
         url = args.first
         return nil unless url
-        get("oembed?url=#{url}", {}, false, false, true)
+        get("/https://api.instagram.com/oembed?url=#{url}", {}, false, false, true)
       end
     end
   end


### PR DESCRIPTION
fix for issue #162