### PR TITLE
Remove unused error Instagram::RateLimitExceeded

### DIFF
--- a/lib/instagram/error.rb
+++ b/lib/instagram/error.rb
@@ -25,7 +25,4 @@ module Instagram
 
   # Raised when a subscription payload hash is invalid
   class InvalidSignature < Error; end
-
-  # Raised when Instagram returns the HTTP status code 429
-  class RateLimitExceeded < Error; end
 end


### PR DESCRIPTION
The custom error class ```Instagram::RateLimitExceeded``` is never used anywhere, therefore we should remove it. Instead ```Instagram::TooManyRequests``` is triggered on HTTP responses with status 429.  This duplication already led to some confusion, see #168.