### PR TITLE
Handle HTTP 400 HTML contained response as empty JSON

### DIFF
--- a/lib/faraday/raise_http_exception.rb
+++ b/lib/faraday/raise_http_exception.rb
@@ -40,7 +40,16 @@ module FaradayMiddleware
       # body gets passed as a string, not sure if it is passed as something else from other spots?
       if not body.nil? and not body.empty? and body.kind_of?(String)
         # removed multi_json thanks to wesnolte's commit
-        body = ::JSON.parse(body)
+        body = begin
+          ::JSON.parse(body)
+        rescue JSON::ParserError => e
+          # handle HTML response here as empty JSON
+          if e.message.match /unexpected token/
+            nil
+          else
+            raise e
+          end
+        end
       end
 
       if body.nil?

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -54,6 +54,20 @@ describe Faraday::Response do
     end
   end
 
+  context "when a 400 is raised with an HTML response" do
+    before do
+      stub_get('users/self/feed.json').to_return(
+        :body => '<html><body><h1>400 Bad Request</h1> The server returned an invalid or incomplete response. </body></html>',
+        :status => 400)
+    end
+
+    it "should return the body error type" do
+      expect do
+        @client.user_media_feed()
+      end.to raise_error(Instagram::BadRequest)
+    end
+  end
+
   context 'when a 502 is raised with an HTML response' do
     before do
       stub_get('users/self/feed.json').to_return(


### PR DESCRIPTION
On production server in one of our product we periodically see the error with trace:
```
Message:
757: unexpected token at '<!DOCTYPE html>
<!--[if lt IE 7]>      <html lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7 not-logged-in "> <![endif]-->
<!--[if IE 7]>         <html lang="en" class="no-js lt-ie9 lt-ie8 not-logged-in "> <![endif]-->
<!--[if I

Exception Class:
JSON::ParserError

/usr/local/lib/ruby/2.1.0/json/common.rb:155:in `parse'
/usr/local/lib/ruby/2.1.0/json/common.rb:155:in `parse'
/ruby/2.1.0/gems/instagram-1.1.3/lib/faraday/raise_http_exception.rb:43:in `error_body'
/ruby/2.1.0/gems/instagram-1.1.3/lib/faraday/raise_http_exception.rb:36:in `error_message_400'
/ruby/2.1.0/gems/instagram-1.1.3/lib/faraday/raise_http_exception.rb:13:in `block in call'
/ruby/2.1.0/gems/faraday-0.9.1/lib/faraday/response.rb:57:in `on_complete'
/ruby/2.1.0/gems/instagram-1.1.3/lib/faraday/raise_http_exception.rb:8:in `call'
/ruby/2.1.0/gems/faraday_middleware-0.9.1/lib/faraday_middleware/response_middleware.rb:30:in `call'
/ruby/2.1.0/gems/faraday-0.9.1/lib/faraday/response.rb:8:in `call'
/ruby/2.1.0/gems/faraday-0.9.1/lib/faraday/request/url_encoded.rb:15:in `call'
/ruby/2.1.0/gems/instagram-1.1.3/lib/faraday/oauth2.rb:33:in `call'
/ruby/2.1.0/gems/faraday-0.9.1/lib/faraday/rack_builder.rb:139:in `build_response'
/ruby/2.1.0/gems/faraday-0.9.1/lib/faraday/connection.rb:377:in `run_request'
/ruby/2.1.0/gems/faraday-0.9.1/lib/faraday/connection.rb:140:in `get'
/ruby/2.1.0/gems/instagram-1.1.3/lib/instagram/request.rb:31:in `request'
```
I think it is quite reasonable to handle unexpected HTML response as empty JSON.