### PR TITLE
fixed requires for faraday + typhoeus

### DIFF
--- a/lib/faraday/loud_logger.rb
+++ b/lib/faraday/loud_logger.rb
@@ -1,4 +1,7 @@
 require 'faraday'
+#if using typhoeus as the adapter uncomment these two requires to avoid seeing "Ethon::Errors::InvalidOption: The option: disable_ssl_peer_verification is invalid." (https://github.com/typhoeus/typhoeus/issues/270)
+#require 'typhoeus'
+#require 'typhoeus/adapters/faraday'
 
 # @private
 module FaradayMiddleware

--- a/lib/faraday/oauth2.rb
+++ b/lib/faraday/oauth2.rb
@@ -1,4 +1,7 @@
 require 'faraday'
+#if using typhoeus as the adapter uncomment these two requires to avoid seeing "Ethon::Errors::InvalidOption: The option: disable_ssl_peer_verification is invalid." (https://github.com/typhoeus/typhoeus/issues/270)
+#require 'typhoeus'
+#require 'typhoeus/adapters/faraday'
 
 # @private
 module FaradayMiddleware

--- a/lib/faraday/raise_http_exception.rb
+++ b/lib/faraday/raise_http_exception.rb
@@ -1,4 +1,7 @@
 require 'faraday'
+#if using typhoeus as the adapter uncomment these two requires to avoid seeing "Ethon::Errors::InvalidOption: The option: disable_ssl_peer_verification is invalid." (https://github.com/typhoeus/typhoeus/issues/270)
+#require 'typhoeus'
+#require 'typhoeus/adapters/faraday'
 
 # @private
 module FaradayMiddleware

--- a/lib/instagram/configuration.rb
+++ b/lib/instagram/configuration.rb
@@ -1,4 +1,7 @@
 require 'faraday'
+#if using typhoeus as the adapter uncomment these two requires to avoid seeing "Ethon::Errors::InvalidOption: The option: disable_ssl_peer_verification is invalid." (https://github.com/typhoeus/typhoeus/issues/270)
+#require 'typhoeus'
+#require 'typhoeus/adapters/faraday'
 require File.expand_path('../version', __FILE__)
 
 module Instagram


### PR DESCRIPTION
If using typhoeus as the adapter `Ethon::Errors::InvalidOption: The option: disable_ssl_peer_verification is invalid.` is thrown unless these two requires are added to `lib/faraday/*.rb`
```
require 'faraday'
require 'typhoeus' #+
require 'typhoeus/adapters/faraday' #+
```

by adding these requires (commented out) it is now easier to use `typhoeus`—all you have to do is uncomment out the requires and change the `DEFAULT_ADAPTER` to `:typhoeus` in `configuration.rb`

this is an implementation of https://github.com/typhoeus/typhoeus/issues/270